### PR TITLE
docs: update style to match docs site

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -53,7 +53,7 @@ This option does not support syncing and provisioning licenses.
     </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ### Option 2: Generate a service account token
 
@@ -80,7 +80,7 @@ An Asana super admin using an Asana Enterprise plan must complete this task.
     </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the Asana connector
 
@@ -139,7 +139,7 @@ An Asana super admin using an Asana Enterprise plan must complete this task.
     </Step>
 </Steps>
 
-**That's it!** Your Asana connector is now pulling access data into C1.
+**Done.** Your Asana connector is now pulling access data into C1.
 </Tab>
 <Tab title="Self-hosted">
 **Follow these instructions to use the Asana connector, hosted and run in your own environment.**
@@ -262,6 +262,6 @@ spec:
     </Step>
 </Steps>
 
-**That's it!** Your Asana connector is now pulling access data into C1.
+**Done.** Your Asana connector is now pulling access data into C1.
 </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary

Syncs `docs/connector.mdx` style with the canonical docs site to prevent regressions on next release.

Changes applied where present:
- Docker image URL: `ghcr.io/conductorone/` → `public.ecr.aws/conductorone/`
- Phrasing: `**That's it!**` → `**Done.**`
- Icon color: `#65DE23` → `#c937ae`
- Branding: `ConductorOne` → `C1` in product references
- GitHub URLs: lowercased org name

These match the [docs site](https://docs.conductorone.com) and were identified via an automated sync audit.