### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/enterprise_users.go
+++ b/pkg/connector/enterprise_users.go
@@ -122,15 +122,18 @@ func enterpriseUserResource(ctx context.Context, user *asana.ScimUser, parentRes
 	}
 
 	userTraitOptions := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
 		rs.WithEmail(email, true),
+	}
+
+	resourceOptions := []rs.ResourceOption{
+		rs.WithResourceProfile(profile),
 	}
 
 	// Set user status based on active flag
 	if user.Active {
-		userTraitOptions = append(userTraitOptions, rs.WithStatus(v2.UserTrait_Status_STATUS_ENABLED))
+		resourceOptions = append(resourceOptions, rs.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, ""))
 	} else {
-		userTraitOptions = append(userTraitOptions, rs.WithStatus(v2.UserTrait_Status_STATUS_DISABLED))
+		resourceOptions = append(resourceOptions, rs.WithResourceStatus(v2.Status_RESOURCE_STATUS_DISABLED, ""))
 	}
 
 	displayName := user.Name.Formatted
@@ -143,7 +146,7 @@ func enterpriseUserResource(ctx context.Context, user *asana.ScimUser, parentRes
 		resourceTypeUser,
 		user.ID,
 		userTraitOptions,
-		rs.WithParentResourceID(parentResourceID),
+		append(resourceOptions, rs.WithParentResourceID(parentResourceID))...,
 	)
 	if err != nil {
 		return nil, err
@@ -214,12 +217,7 @@ func (o *enterpriseUserResourceType) Entitlements(_ context.Context, _ *v2.Resou
 
 func (o *enterpriseUserResourceType) Grants(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
 	// Enterprise users can have license grants
-	userTrait, err := rs.GetUserTrait(resource)
-	if err != nil {
-		return nil, "", nil, fmt.Errorf("failed to get user trait: %w", err)
-	}
-
-	profile := userTrait.Profile.AsMap()
+	profile := resource.GetProfile().AsMap()
 	userType, ok := profile["user_type"].(string)
 	if !ok || userType == "" {
 		// No user type means no license

--- a/pkg/connector/enterprise_users.go
+++ b/pkg/connector/enterprise_users.go
@@ -217,7 +217,7 @@ func (o *enterpriseUserResourceType) Entitlements(_ context.Context, _ *v2.Resou
 
 func (o *enterpriseUserResourceType) Grants(ctx context.Context, resource *v2.Resource, _ *pagination.Token) ([]*v2.Grant, string, annotations.Annotations, error) {
 	// Enterprise users can have license grants
-	profile := resource.GetProfile().AsMap()
+	profile := rs.GetProfile(resource).AsMap()
 	userType, ok := profile["user_type"].(string)
 	if !ok || userType == "" {
 		// No user type means no license

--- a/pkg/connector/license.go
+++ b/pkg/connector/license.go
@@ -46,9 +46,8 @@ func licenseResource(ctx context.Context, licenseType string) (*v2.Resource, err
 		displayName,
 		resourceTypeLicense,
 		licenseType,
-		[]rs.RoleTraitOption{
-			rs.WithRoleProfile(profile),
-		},
+		[]rs.RoleTraitOption{},
+		rs.WithResourceProfile(profile),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/team.go
+++ b/pkg/connector/team.go
@@ -44,13 +44,14 @@ func teamResource(team *asana.Team, parentResourceID *v2.ResourceId) (*v2.Resour
 		"team_name": team.Name,
 	}
 
-	groupTraitOptions := []rs.GroupTraitOption{rs.WithGroupProfile(profile)}
+	groupTraitOptions := []rs.GroupTraitOption{}
 
 	ret, err := rs.NewGroupResource(
 		team.Name,
 		resourceTypeTeam,
 		team.Gid,
 		groupTraitOptions,
+		rs.WithResourceProfile(profile),
 		rs.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -50,9 +50,7 @@ func userResource(ctx context.Context, user *asana.User, parentResourceID *v2.Re
 	}
 
 	userTraitOptions := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
 		rs.WithEmail(user.Email, true),
-		rs.WithStatus(v2.UserTrait_Status_STATUS_ENABLED),
 	}
 
 	ret, err := rs.NewUserResource(
@@ -60,6 +58,8 @@ func userResource(ctx context.Context, user *asana.User, parentResourceID *v2.Re
 		resourceTypeUser,
 		user.Gid,
 		userTraitOptions,
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, ""),
 		rs.WithParentResourceID(parentResourceID),
 	)
 	if err != nil {

--- a/pkg/connector/workspace.go
+++ b/pkg/connector/workspace.go
@@ -159,7 +159,7 @@ func (o *workspaceResourceType) Grants(ctx context.Context, resource *v2.Resourc
 		return nil, "", nil, err
 	}
 
-	workspaceId, ok := rs.GetProfileStringValue(resource.GetProfile(), "workspace_id")
+	workspaceId, ok := rs.GetProfileStringValue(rs.GetProfile(resource), "workspace_id")
 	if !ok {
 		return nil, "", nil, fmt.Errorf("error fetching workspace_id from workspace profile")
 	}

--- a/pkg/connector/workspace.go
+++ b/pkg/connector/workspace.go
@@ -56,10 +56,9 @@ func workspaceResource(ctx context.Context, workspace asana.Workspace) (*v2.Reso
 	profile["workspace_name"] = workspace.Name
 	profile["is_organization"] = workspace.IsOrganization
 
-	groupTrait := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
+	groupTrait := []rs.GroupTraitOption{}
 	workspaceOptions := []rs.ResourceOption{
+		rs.WithResourceProfile(profile),
 		rs.WithAnnotation(
 			&v2.ChildResourceType{ResourceTypeId: resourceTypeUser.Id},
 			&v2.ChildResourceType{ResourceTypeId: resourceTypeTeam.Id},
@@ -160,12 +159,7 @@ func (o *workspaceResourceType) Grants(ctx context.Context, resource *v2.Resourc
 		return nil, "", nil, err
 	}
 
-	workspaceTrait, err := rs.GetGroupTrait(resource)
-	if err != nil {
-		return nil, "", nil, err
-	}
-
-	workspaceId, ok := rs.GetProfileStringValue(workspaceTrait.Profile, "workspace_id")
+	workspaceId, ok := rs.GetProfileStringValue(resource.GetProfile(), "workspace_id")
 	if !ok {
 		return nil, "", nil, fmt.Errorf("error fetching workspace_id from workspace profile")
 	}


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
